### PR TITLE
Docker garbage cleanup uses events to determine image usage

### DIFF
--- a/docker_custodian/__about__.py
+++ b/docker_custodian/__about__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf8 -*-
 
-__version_info__ = (0, 6, 0)
+__version_info__ = (0, 7, 0)
 __version__ = '%d.%d.%d' % __version_info__


### PR DESCRIPTION
Docker garbage cleanup only pays attention to when the image was built.  This presents issues when trying to use an image that was built weeks ago but is in current use.  In order to deal with this issue, we have added the max-image-usage flag, which will not cleanup an image if it has a recent push, pull or tag event.